### PR TITLE
Make the decimal parsing in GetBalance cultureInvariant.

### DIFF
--- a/Services/API/REST.cs
+++ b/Services/API/REST.cs
@@ -126,7 +126,7 @@ namespace Clickatell.Services.API
                 {
                     Result = response.Result,
                     Success = true,
-                    Credit = decimal.Parse(jsonBalance)
+                    Credit = decimal.Parse(jsonBalance, System.Globalization.CultureInfo.InvariantCulture)
                 };
             }
             catch (Exception exception)


### PR DESCRIPTION
GetBalance fails on cultures with comma as decimal seperator. This makes the GetBalance decimal parsing culture invariant.
